### PR TITLE
Add fallback logic for CPUs that don't support SSE4.1.

### DIFF
--- a/simd/src/scalar/mod.rs
+++ b/simd/src/scalar/mod.rs
@@ -584,7 +584,7 @@ impl Mul<I32x2> for I32x2 {
 // Four 32-bit signed integers
 
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
-pub struct I32x4([i32; 4]);
+pub struct I32x4(pub [i32; 4]);
 
 impl I32x4 {
     #[inline]

--- a/simd/src/x86/mod.rs
+++ b/simd/src/x86/mod.rs
@@ -268,12 +268,28 @@ impl F32x4 {
 
     #[inline]
     pub fn floor(self) -> F32x4 {
-        unsafe { F32x4(x86::_mm_floor_ps(self.0)) }
+        unsafe {
+            if std::is_x86_feature_detected!("sse4.1") {
+                F32x4(x86::_mm_floor_ps(self.0))
+            } else {
+                F32x4(std::mem::transmute(
+                    crate::scalar::F32x4(std::mem::transmute(self.0)).floor(),
+                ))
+            }
+        }
     }
 
     #[inline]
     pub fn ceil(self) -> F32x4 {
-        unsafe { F32x4(x86::_mm_ceil_ps(self.0)) }
+        unsafe {
+            if std::is_x86_feature_detected!("sse4.1") {
+                F32x4(x86::_mm_ceil_ps(self.0))
+            } else {
+                F32x4(std::mem::transmute(
+                    crate::scalar::F32x4(std::mem::transmute(self.0)).ceil(),
+                ))
+            }
+        }
     }
 
     #[inline]
@@ -702,12 +718,30 @@ impl I32x4 {
 
     #[inline]
     pub fn max(self, other: I32x4) -> I32x4 {
-        unsafe { I32x4(x86::_mm_max_epi32(self.0, other.0)) }
+        unsafe {
+            if std::is_x86_feature_detected!("sse4.1") {
+                I32x4(x86::_mm_max_epi32(self.0, other.0))
+            } else {
+                I32x4(std::mem::transmute(
+                    crate::scalar::I32x4(std::mem::transmute(self.0))
+                        .max(std::mem::transmute(other.0)),
+                ))
+            }
+        }
     }
 
     #[inline]
     pub fn min(self, other: I32x4) -> I32x4 {
-        unsafe { I32x4(x86::_mm_min_epi32(self.0, other.0)) }
+        unsafe {
+            if std::is_x86_feature_detected!("sse4.1") {
+                I32x4(x86::_mm_min_epi32(self.0, other.0))
+            } else {
+                I32x4(std::mem::transmute(
+                    crate::scalar::I32x4(std::mem::transmute(self.0))
+                        .min(std::mem::transmute(other.0)),
+                ))
+            }
+        }
     }
 
     // Packed comparisons
@@ -777,7 +811,16 @@ impl Mul<I32x4> for I32x4 {
     type Output = I32x4;
     #[inline]
     fn mul(self, other: I32x4) -> I32x4 {
-        unsafe { I32x4(x86::_mm_mullo_epi32(self.0, other.0)) }
+        unsafe {
+            if std::is_x86_feature_detected!("sse4.1") {
+                I32x4(x86::_mm_mullo_epi32(self.0, other.0))
+            } else {
+                I32x4(std::mem::transmute(
+                    crate::scalar::I32x4(std::mem::transmute(self.0))
+                        * std::mem::transmute(other.0),
+                ))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Not all of our users have CPUs that support SSE4.1, which includes some instructions used in this crate.

To address this, I've updated the relevant functions to perform runtime checks for SSE4.1 support and fall back to a scalar implementation if need be.

## Testing

- [x] Ran tests with the conditionals forced to false to ensure that the implementations are correct.
- [x] Did some performance analysis to ensure that this doesn't introduce noticeable regressions for users with SSE4.1 support.  (Ran `termbench` and validated that the results are comparable.  This should be a decent test, as it produces output at a fast enough rate that we're basically constantly redrawing the UI, which involves a lot of `Vector2F` logic.)