### PR TITLE
fix: update follow-redirects to resolve GHSA-r4q5-vmmm-2653

### DIFF
--- a/examples/canvas_webgl_minimal/www/package-lock.json
+++ b/examples/canvas_webgl_minimal/www/package-lock.json
@@ -2150,9 +2150,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true
     },
     "for-in": {


### PR DESCRIPTION
## Summary
- Updates the transitive npm dev dependency `follow-redirects` from `1.14.7` to `1.16.0` in `examples/canvas_webgl_minimal/www/package-lock.json`.
- Resolves the selected `follow-redirects` Dependabot alert batch:
  - https://github.com/warpdotdev/pathfinder/security/dependabot/10
  - https://github.com/warpdotdev/pathfinder/security/dependabot/26
  - https://github.com/warpdotdev/pathfinder/security/dependabot/28
  - https://github.com/warpdotdev/pathfinder/security/dependabot/88

## Vulnerability details
- Package: `follow-redirects`
- Ecosystem: npm
- Manifest: `examples/canvas_webgl_minimal/www/package-lock.json`
- Dependency relationship/scope: transitive development dependency via `http-proxy`
- Patched version used: `1.16.0`
- Advisories:
  - CVE-2022-0536: https://github.com/advisories/GHSA-pw2r-vq6v-hr8c
  - CVE-2023-26159: https://github.com/advisories/GHSA-cxjh-pqwp-8mfp
  - CVE-2024-28849: https://github.com/advisories/GHSA-cxjh-pqwp-8mfp
  - GHSA-r4q5-vmmm-2653: https://github.com/advisories/GHSA-r4q5-vmmm-2653

## Verification
- `git diff --check`
- `python3 -m json.tool examples/canvas_webgl_minimal/www/package-lock.json`
- `cd examples/canvas_webgl_minimal/www && npm audit --json` confirms `follow-redirects` is no longer reported.
- `cd examples/canvas_webgl_minimal && cargo build`
- `cd examples/canvas_webgl_minimal && wasm-pack build` generated the wasm package.
- `NODE_OPTIONS=--openssl-legacy-provider npm run build` was attempted after generating the wasm package, but the existing legacy webpack 4 wasm parser path fails on `canvas_webgl_minimal_bg.wasm` with `Module parse failed: Unexpected section: 0xc`, which appears unrelated to this lockfile-only dependency update.

_Conversation: https://staging.warp.dev/conversation/cd8ccf40-19ac-4980-beb6-f83389626371_
_Run: https://oz.staging.warp.dev/runs/019e799d-296f-715e-96a9-2a854f84da58_
_This PR was generated with [Oz](https://warp.dev/oz)._
